### PR TITLE
doc: minor typo fix  in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Crypto secp256k1 + wasm. Implemented: bip32, bip39, bip44, bip49, bip84, bip141. NIST random generation tests on the fly for entropy. Shamir's secret sharing for mnemonic.
 
 ### Build
-    npm install jsbgl.js
+    npm install jsbgl
     npm run build:wasm:prebuild
     npm run build:wasm
     npm run build


### PR DESCRIPTION
## Summary

1. Minor typo fix from `jsbgl.js` to `jsbgl` . The module is published as `jsbgl` and not `jsbgl.js` which can be misleading.

Context: doing `npm install jsbgl.js` throws the following error
```sh 
[nmurgor@nmurgor src]$  npm install jsbgl.js
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/jsbgl.js - Not found
npm ERR! 404 
npm ERR! 404  'jsbgl.js@latest' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/nmurgor/.npm/_logs/2023-03-16T06_41_26_673Z-debug.log
```