### PR TITLE
fix: reject mixed-case bech32 addresses

### DIFF
--- a/dist/functions/address.js
+++ b/dist/functions/address.js
@@ -183,6 +183,7 @@ module.exports = function (S) {
       return checksum.equals(verifyChecksum);
     } else {
       var prefix, payload;
+      if (address !== address.toLowerCase() && address !== address.toUpperCase()) return false;
 
       if ([S.TESTNET_SEGWIT_ADDRESS_PREFIX, S.MAINNET_SEGWIT_ADDRESS_PREFIX].includes(address.split("1")[0].toLowerCase())) {
         if (address.length !== 43 && address.length !== 63 && address.length !== 44 && address.length !== 64) return false;

--- a/src/functions/address.js
+++ b/src/functions/address.js
@@ -205,6 +205,7 @@ module.exports = function (S) {
 
         } else {
             let prefix, payload;
+            if (address !== address.toLowerCase() && address !== address.toUpperCase()) return false;
             if ([S.TESTNET_SEGWIT_ADDRESS_PREFIX,
                 S.MAINNET_SEGWIT_ADDRESS_PREFIX].includes(address.split("1")[0].toLowerCase())) {
                 if (address.length !== 43 && address.length !== 63 && address.length !== 44 && address.length !== 64) return false;

--- a/test/jsbgl.test.js
+++ b/test/jsbgl.test.js
@@ -845,6 +845,8 @@ describe(`${(browser) ? 'Browser' : 'Node'} test jsbgl library`, function () {
             equal(isAddressValid("BGL1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7K0FY5A3"), true);
             equal(isAddressValid("Bgl1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7K0FY5A3"), false);
             equal(isAddressValid("tbgl1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx", {testnet: true}), true);
+            equal(isAddressValid("TBGL1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KXPJZSX", {testnet: true}), true);
+            equal(isAddressValid("Tbgl1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KXPJZSX", {testnet: true}), false);
             equal(isAddressValid("tbgl1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"), false);
             // equal(isAddressValid("bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"), true);
             // equal(isAddressValid("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7", {testnet: true}), true);

--- a/test/jsbgl.test.js
+++ b/test/jsbgl.test.js
@@ -842,6 +842,8 @@ describe(`${(browser) ? 'Browser' : 'Node'} test jsbgl library`, function () {
 
         it('isAddressValid', () => {
             equal(isAddressValid("bgl1qw508d6qejxtdg4y5r3zarvary0c5xw7k0fy5a3"), true);
+            equal(isAddressValid("BGL1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7K0FY5A3"), true);
+            equal(isAddressValid("Bgl1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7K0FY5A3"), false);
             equal(isAddressValid("tbgl1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx", {testnet: true}), true);
             equal(isAddressValid("tbgl1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"), false);
             // equal(isAddressValid("bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"), true);


### PR DESCRIPTION
## Summary
- Reject mixed-case Bech32/SegWit addresses in `isAddressValid()` before checksum normalization.
- Keep all-lowercase and all-uppercase Bech32 addresses valid, but reject mixed-case strings per BIP173.
- Add regression coverage and update the distributed `dist/functions/address.js` entry point used by the package main.

## RED proof
With the new regression added before the fix, `npm test` failed in `Address functions: isAddressValid`:

```text
AssertionError: expected true to equal false
-true
+false
```

The failing address was a mixed-case BGL Bech32 address: `Bgl1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7K0FY5A3`.

## GREEN proof
```bash
npm test
```

Result: `68 passing`.

```bash
node - <<'NODE'
const assert = require('assert');
const jsbgl = require('./');
(async () => {
  await jsbgl.asyncInit(global);
  assert.strictEqual(isAddressValid('bgl1qw508d6qejxtdg4y5r3zarvary0c5xw7k0fy5a3'), true);
  assert.strictEqual(isAddressValid('BGL1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7K0FY5A3'), true);
  assert.strictEqual(isAddressValid('Bgl1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7K0FY5A3'), false);
  console.log('dist/package bech32 mixed-case regression ok');
})();
NODE
```

Result: `dist/package bech32 mixed-case regression ok`.

```bash
git diff --check
```

Result: clean.

## Bounty context
This is submitted as a Bitgesell improvement/bugfix PR for the public bounty/improvement program:
- https://github.com/BitgesellOfficial/bitgesell/issues/81
- https://github.com/BitgesellOfficial/bitgesell/issues/39